### PR TITLE
Fix missing nav hist to unopened files and origin name fix

### DIFF
--- a/crates/agent_ui/src/agent_diff.rs
+++ b/crates/agent_ui/src/agent_diff.rs
@@ -523,7 +523,7 @@ impl Item for AgentDiffPane {
 
     fn navigate(
         &mut self,
-        data: Box<dyn Any>,
+        data: Arc<dyn Any + Send>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {

--- a/crates/agent_ui/src/text_thread_editor.rs
+++ b/crates/agent_ui/src/text_thread_editor.rs
@@ -43,7 +43,7 @@ use rope::Point;
 use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsStore, update_settings_file};
 use std::{
-    any::TypeId,
+    any::{Any, TypeId},
     cmp,
     ops::Range,
     path::{Path, PathBuf},
@@ -2518,7 +2518,7 @@ impl Item for TextThreadEditor {
 
     fn navigate(
         &mut self,
-        data: Box<dyn std::any::Any>,
+        data: Arc<dyn Any + Send>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {

--- a/crates/collab_ui/src/channel_view.rs
+++ b/crates/collab_ui/src/channel_view.rs
@@ -514,7 +514,7 @@ impl Item for ChannelView {
 
     fn navigate(
         &mut self,
-        data: Box<dyn Any>,
+        data: Arc<dyn Any + Send>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {

--- a/crates/debugger_ui/src/stack_trace_view.rs
+++ b/crates/debugger_ui/src/stack_trace_view.rs
@@ -1,4 +1,7 @@
-use std::any::{Any, TypeId};
+use std::{
+    any::{Any, TypeId},
+    sync::Arc,
+};
 
 use collections::HashMap;
 use dap::StackFrameId;
@@ -330,7 +333,7 @@ impl Item for StackTraceView {
 
     fn navigate(
         &mut self,
-        data: Box<dyn Any>,
+        data: Arc<dyn Any + Send>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {

--- a/crates/diagnostics/src/buffer_diagnostics.rs
+++ b/crates/diagnostics/src/buffer_diagnostics.rs
@@ -734,7 +734,7 @@ impl Item for BufferDiagnosticsEditor {
 
     fn navigate(
         &mut self,
-        data: Box<dyn Any>,
+        data: Arc<dyn Any + Send>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -642,7 +642,7 @@ impl Item for ProjectDiagnosticsEditor {
 
     fn navigate(
         &mut self,
-        data: Box<dyn Any>,
+        data: Arc<dyn Any + Send>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -13854,6 +13854,15 @@ impl Editor {
         }
     }
 
+    pub fn create_tag_stack_entry(&self, tag: Option<String>, cx: &App) {
+        let Some(mut history) = self.nav_history.clone() else {
+            return;
+        };
+        let anchor = self.selections.newest_anchor().head();
+        let nav_data = self.navigation_data(anchor, cx);
+        history.push_tag(tag, Some(nav_data));
+    }
+
     fn push_to_nav_history(
         &mut self,
         cursor_anchor: Anchor,
@@ -16321,7 +16330,7 @@ impl Editor {
         let definitions: Vec<_> = definitions
             .into_iter()
             .filter_map(|def| match def {
-                HoverLink::Text(link) => Some(Task::ready(anyhow::Ok(Some(link.target)))),
+                HoverLink::Text(link) => Some(Task::ready(anyhow::Ok(Some(link)))),
                 HoverLink::InlayHint(lsp_location, server_id) => {
                     let computation =
                         self.compute_target_location(lsp_location, server_id, window, cx);
@@ -16338,10 +16347,15 @@ impl Editor {
             })
             .collect();
 
+        // Always push a nav history entry with the editor state prior to
+        // jumping away. This allows users to always return to the exact spot
+        // they jumped from, not e.g., a nearby spot
+        self.create_nav_history_entry(cx);
+
         let workspace = self.workspace();
 
         cx.spawn_in(window, async move |editor, acx| {
-            let mut locations: Vec<Location> = future::join_all(definitions)
+            let mut locations: Vec<LocationLink> = future::join_all(definitions)
                 .await
                 .into_iter()
                 .filter_map(|location| location.transpose())
@@ -16365,9 +16379,10 @@ impl Editor {
                             .iter()
                             .map(|location| {
                                 location
+                                    .target
                                     .buffer
                                     .read(cx)
-                                    .text_for_range(location.range.clone())
+                                    .text_for_range(location.target.range.clone())
                                     .collect::<String>()
                             })
                             .filter(|text| !text.contains('\n'))
@@ -16382,21 +16397,31 @@ impl Editor {
                     })
                     .context("buffer title")?;
 
-                let opened = workspace
-                    .update_in(acx, |workspace, window, cx| {
-                        Self::open_locations_in_multibuffer(
-                            workspace,
-                            locations,
-                            title,
-                            split,
-                            MultibufferSelectionMode::First,
-                            window,
-                            cx,
-                        )
-                    })
-                    .is_ok();
-
-                anyhow::Ok(Navigated::from_bool(opened))
+                workspace.update_in(acx, |workspace, window, cx| {
+                    let tag = locations.iter().find_map(|loc_link| {
+                        loc_link.origin.as_ref().map(|origin| {
+                            origin.buffer.read_with(cx, |buffer, _cx| {
+                                let snapshot = buffer.snapshot();
+                                snapshot
+                                    .text_for_range(origin.range.clone())
+                                    .collect::<String>()
+                            })
+                        })
+                    });
+                    let Some(ed) = Self::open_locations_in_multibuffer(
+                        workspace,
+                        locations.iter().map(|item| item.target.clone()).collect(),
+                        title,
+                        split,
+                        MultibufferSelectionMode::First,
+                        window,
+                        cx,
+                    ) else {
+                        return Navigated::No;
+                    };
+                    ed.read(cx).create_tag_stack_entry(tag, cx);
+                    Navigated::Yes
+                })
             } else if locations.is_empty() {
                 // If there is one url or file, open it directly
                 match first_url_or_file {
@@ -16423,16 +16448,27 @@ impl Editor {
                     return Ok(Navigated::No);
                 };
 
-                let target = locations.pop().unwrap();
+                let location = locations.pop().unwrap();
+                let target = location.target;
                 editor.update_in(acx, |editor, window, cx| {
                     let range = target.range.to_point(target.buffer.read(cx));
                     let range = editor.range_for_match(&range);
                     let range = collapse_multiline_range(range);
 
+                    let tag = location.origin.map(|origin| {
+                        origin.buffer.read_with(cx, |buffer, _cx| {
+                            let snapshot = buffer.snapshot();
+                            snapshot
+                                .text_for_range(origin.range.clone())
+                                .collect::<String>()
+                        })
+                    });
+
                     if !split
                         && Some(&target.buffer) == editor.buffer.read(cx).as_singleton().as_ref()
                     {
                         editor.go_to_singleton_buffer_range(range, window, cx);
+                        editor.create_tag_stack_entry(tag, cx);
                     } else {
                         let pane = workspace.read(cx).active_pane().clone();
                         window.defer(cx, move |window, cx| {
@@ -16459,6 +16495,7 @@ impl Editor {
                                 pane.update(cx, |pane, _| pane.disable_history());
                                 target_editor.go_to_singleton_buffer_range(range, window, cx);
                                 pane.update(cx, |pane, _| pane.enable_history());
+                                target_editor.create_tag_stack_entry(tag, cx);
                             });
                         });
                     }
@@ -16474,7 +16511,7 @@ impl Editor {
         server_id: LanguageServerId,
         window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> Task<anyhow::Result<Option<Location>>> {
+    ) -> Task<anyhow::Result<Option<LocationLink>>> {
         let Some(project) = self.project.clone() else {
             return Task::ready(Ok(None));
         };
@@ -16495,9 +16532,12 @@ impl Editor {
                     target_buffer.anchor_after(target_start)
                         ..target_buffer.anchor_before(target_end)
                 })?;
-                Location {
-                    buffer: target_buffer_handle,
-                    range,
+                LocationLink {
+                    origin: None,
+                    target: Location {
+                        buffer: target_buffer_handle,
+                        range,
+                    },
                 }
             });
             Ok(location)
@@ -16602,10 +16642,10 @@ impl Editor {
         multibuffer_selection_mode: MultibufferSelectionMode,
         window: &mut Window,
         cx: &mut Context<Workspace>,
-    ) {
+    ) -> Option<Entity<Editor>> {
         if locations.is_empty() {
             log::error!("bug: open_locations_in_multibuffer called with empty list of locations");
-            return;
+            return None;
         }
 
         locations.sort_by_key(|location| location.buffer.read(cx).remote_id());
@@ -16711,7 +16751,7 @@ impl Editor {
             editor.register_buffers_with_language_servers(cx);
         });
 
-        let item = Box::new(editor);
+        let item = Box::new(editor.clone());
         let item_id = item.item_id();
 
         if split {
@@ -16733,8 +16773,12 @@ impl Editor {
             workspace.add_item_to_active_pane(item, None, true, window, cx);
         }
         workspace.active_pane().update(cx, |pane, cx| {
+            let nav_history = pane.nav_history_for_item(&editor);
+            editor.update(cx, |ed, _cx| ed.set_nav_history(Some(nav_history)));
             pane.set_preview_item_id(Some(item_id), cx);
         });
+
+        Some(editor)
     }
 
     pub fn rename(

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -13839,6 +13839,21 @@ impl Editor {
         );
     }
 
+    fn navigation_data(&self, cursor_anchor: Anchor, cx: &App) -> NavigationData {
+        let buffer = self.buffer.read(cx).read(cx);
+        let cursor_position = cursor_anchor.to_point(&buffer);
+        let scroll_anchor = self.scroll_manager.anchor();
+        let scroll_top_row = scroll_anchor.top_row(&buffer);
+        drop(buffer);
+
+        NavigationData {
+            cursor_anchor,
+            cursor_position,
+            scroll_anchor,
+            scroll_top_row,
+        }
+    }
+
     fn push_to_nav_history(
         &mut self,
         cursor_anchor: Anchor,
@@ -13847,29 +13862,16 @@ impl Editor {
         always: bool,
         cx: &mut Context<Self>,
     ) {
+        let data = self.navigation_data(cursor_anchor, cx);
         if let Some(nav_history) = self.nav_history.as_mut() {
-            let buffer = self.buffer.read(cx).read(cx);
-            let cursor_position = cursor_anchor.to_point(&buffer);
-            let scroll_state = self.scroll_manager.anchor();
-            let scroll_top_row = scroll_state.top_row(&buffer);
-            drop(buffer);
-
-            if let Some(new_position) = new_position {
-                let row_delta = (new_position.row as i64 - cursor_position.row as i64).abs();
-                if row_delta == 0 || (row_delta < MIN_NAVIGATION_HISTORY_ROW_DELTA && !always) {
+            if !always && let Some(new_position) = new_position {
+                let row_delta = (new_position.row as i64 - data.cursor_position.row as i64).abs();
+                if row_delta < MIN_NAVIGATION_HISTORY_ROW_DELTA {
                     return;
                 }
             }
 
-            nav_history.push(
-                Some(NavigationData {
-                    cursor_anchor,
-                    cursor_position,
-                    scroll_anchor: scroll_state,
-                    scroll_top_row,
-                }),
-                cx,
-            );
+            nav_history.push(Some(data), cx);
             cx.emit(EditorEvent::PushedToNavHistory {
                 anchor: cursor_anchor,
                 is_deactivate,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -16490,6 +16490,11 @@ impl Editor {
                                     )
                                 });
                             target_editor.update(cx, |target_editor, cx| {
+                                if target_editor.nav_history().is_none() {
+                                    let nav_history =
+                                        pane.read(cx).nav_history_for_item(&cx.entity());
+                                    target_editor.set_nav_history(Some(nav_history));
+                                }
                                 // When selecting a definition in a different buffer, disable the nav history
                                 // to avoid creating a history entry at the previous cursor location.
                                 pane.update(cx, |pane, _| pane.disable_history());
@@ -16532,12 +16537,14 @@ impl Editor {
                     target_buffer.anchor_after(target_start)
                         ..target_buffer.anchor_before(target_end)
                 })?;
+
+                let location = Location {
+                    buffer: target_buffer_handle,
+                    range,
+                };
                 LocationLink {
-                    origin: None,
-                    target: Location {
-                        buffer: target_buffer_handle,
-                        range,
-                    },
+                    origin: Some(location.clone()),
+                    target: location,
                 }
             });
             Ok(location)

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -793,7 +793,7 @@ async fn test_navigation_history(cx: &mut TestAppContext) {
             invalid_anchor.text_anchor.buffer_id = BufferId::new(999).ok();
             let invalid_point = Point::new(9999, 0);
             editor.navigate(
-                Box::new(NavigationData {
+                Arc::new(NavigationData {
                     cursor_anchor: invalid_anchor,
                     cursor_position: invalid_point,
                     scroll_anchor: ScrollAnchor {

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -28,7 +28,7 @@ use project::{
 use rpc::proto::{self, update_view};
 use settings::Settings;
 use std::{
-    any::TypeId,
+    any::{Any, TypeId},
     borrow::Cow,
     cmp::{self, Ordering},
     iter,
@@ -589,11 +589,11 @@ impl Item for Editor {
 
     fn navigate(
         &mut self,
-        data: Box<dyn std::any::Any>,
+        data: Arc<dyn Any + Send>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {
-        if let Ok(data) = data.downcast::<NavigationData>() {
+        if let Some(data) = data.downcast_ref::<NavigationData>() {
             let newest_selection = self.selections.newest::<Point>(cx);
             let buffer = self.buffer.read(cx).read(cx);
             let offset = if buffer.can_resolve(&data.cursor_anchor) {

--- a/crates/editor/src/proposed_changes_editor.rs
+++ b/crates/editor/src/proposed_changes_editor.rs
@@ -7,7 +7,13 @@ use language::{Buffer, BufferEvent, Capability};
 use multi_buffer::{ExcerptRange, MultiBuffer};
 use project::Project;
 use smol::stream::StreamExt;
-use std::{any::TypeId, ops::Range, rc::Rc, time::Duration};
+use std::{
+    any::{Any, TypeId},
+    ops::Range,
+    rc::Rc,
+    sync::Arc,
+    time::Duration,
+};
 use text::ToOffset;
 use ui::{ButtonLike, KeyBinding, prelude::*};
 use workspace::{
@@ -317,7 +323,7 @@ impl Item for ProposedChangesEditor {
 
     fn navigate(
         &mut self,
-        data: Box<dyn std::any::Any>,
+        data: Arc<dyn Any + Send>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -487,7 +487,7 @@ impl Item for CommitView {
 
     fn navigate(
         &mut self,
-        data: Box<dyn Any>,
+        data: Arc<dyn Any + Send>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {

--- a/crates/git_ui/src/file_diff_view.rs
+++ b/crates/git_ui/src/file_diff_view.rs
@@ -307,7 +307,7 @@ impl Item for FileDiffView {
 
     fn navigate(
         &mut self,
-        data: Box<dyn Any>,
+        data: Arc<dyn Any + Send>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -30,8 +30,11 @@ use project::{
     git_store::{GitStore, GitStoreEvent, RepositoryEvent},
 };
 use settings::{Settings, SettingsStore};
-use std::any::{Any, TypeId};
 use std::ops::Range;
+use std::{
+    any::{Any, TypeId},
+    sync::Arc,
+};
 use theme::ActiveTheme;
 use ui::{KeyBinding, Tooltip, prelude::*, vertical_divider};
 use util::ResultExt as _;
@@ -570,7 +573,7 @@ impl Item for ProjectDiff {
 
     fn navigate(
         &mut self,
-        data: Box<dyn Any>,
+        data: Arc<dyn Any + Send>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {

--- a/crates/git_ui/src/text_diff_view.rs
+++ b/crates/git_ui/src/text_diff_view.rs
@@ -368,7 +368,7 @@ impl Item for TextDiffView {
 
     fn navigate(
         &mut self,
-        data: Box<dyn Any>,
+        data: Arc<dyn Any + Send>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -607,7 +607,7 @@ impl Item for ProjectSearchView {
 
     fn navigate(
         &mut self,
-        data: Box<dyn Any>,
+        data: Arc<dyn Any + Send>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -301,7 +301,12 @@ pub trait Item: Focusable + EventEmitter<Self::Event> + Render + Sized {
     fn discarded(&self, _project: Entity<Project>, _window: &mut Window, _cx: &mut Context<Self>) {}
     fn on_removed(&self, _cx: &App) {}
     fn workspace_deactivated(&mut self, _window: &mut Window, _: &mut Context<Self>) {}
-    fn navigate(&mut self, _: Box<dyn Any>, _window: &mut Window, _: &mut Context<Self>) -> bool {
+    fn navigate(
+        &mut self,
+        _: Arc<dyn Any + Send>,
+        _window: &mut Window,
+        _: &mut Context<Self>,
+    ) -> bool {
         false
     }
 
@@ -541,7 +546,7 @@ pub trait ItemHandle: 'static + Send {
     fn deactivated(&self, window: &mut Window, cx: &mut App);
     fn on_removed(&self, cx: &App);
     fn workspace_deactivated(&self, window: &mut Window, cx: &mut App);
-    fn navigate(&self, data: Box<dyn Any>, window: &mut Window, cx: &mut App) -> bool;
+    fn navigate(&self, data: Arc<dyn Any + Send>, window: &mut Window, cx: &mut App) -> bool;
     fn item_id(&self) -> EntityId;
     fn to_any(&self) -> AnyView;
     fn is_dirty(&self, cx: &App) -> bool;
@@ -984,7 +989,7 @@ impl<T: Item> ItemHandle for Entity<T> {
         self.update(cx, |this, cx| this.workspace_deactivated(window, cx));
     }
 
-    fn navigate(&self, data: Box<dyn Any>, window: &mut Window, cx: &mut App) -> bool {
+    fn navigate(&self, data: Arc<dyn Any + Send>, window: &mut Window, cx: &mut App) -> bool {
         self.update(cx, |this, cx| this.navigate(data, window, cx))
     }
 
@@ -1354,7 +1359,7 @@ pub mod test {
         InteractiveElement, IntoElement, Render, SharedString, Task, WeakEntity, Window,
     };
     use project::{Project, ProjectEntryId, ProjectPath, WorktreeId};
-    use std::{any::Any, cell::Cell, path::Path};
+    use std::{any::Any, cell::Cell, path::Path, sync::Arc};
 
     pub struct TestProjectItem {
         pub entry_id: Option<ProjectEntryId>,
@@ -1586,14 +1591,18 @@ pub mod test {
 
         fn navigate(
             &mut self,
-            state: Box<dyn Any>,
+            state: Arc<dyn Any + Send>,
             _window: &mut Window,
             _: &mut Context<Self>,
         ) -> bool {
-            let state = *state.downcast::<String>().unwrap_or_default();
-            if state != self.state {
-                self.state = state;
-                true
+            if let Some(state) = state.downcast_ref::<Box<String>>() {
+                let state = *state.clone();
+                if state != self.state {
+                    false
+                } else {
+                    self.state = state;
+                    true
+                }
             } else {
                 false
             }

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -388,6 +388,7 @@ pub struct ActivationHistoryEntry {
     pub timestamp: usize,
 }
 
+#[derive(Clone)]
 pub struct ItemNavHistory {
     history: NavHistory,
     item: Arc<dyn WeakItemHandle>,
@@ -397,6 +398,7 @@ pub struct ItemNavHistory {
 #[derive(Clone)]
 pub struct NavHistory(Arc<Mutex<NavHistoryState>>);
 
+#[derive(Clone)]
 struct NavHistoryState {
     mode: NavigationMode,
     backward_stack: VecDeque<NavigationEntry>,
@@ -423,9 +425,10 @@ impl Default for NavigationMode {
     }
 }
 
+#[derive(Clone)]
 pub struct NavigationEntry {
     pub item: Arc<dyn WeakItemHandle>,
-    pub data: Option<Box<dyn Any + Send>>,
+    pub data: Option<Arc<dyn Any + Send>>,
     pub timestamp: usize,
     pub is_preview: bool,
 }
@@ -3843,7 +3846,7 @@ impl Render for Pane {
 }
 
 impl ItemNavHistory {
-    pub fn push<D: 'static + Send + Any>(&mut self, data: Option<D>, cx: &mut App) {
+    pub fn push<D: 'static + Any + Send>(&mut self, data: Option<D>, cx: &mut App) {
         if self
             .item
             .upgrade()
@@ -3921,7 +3924,7 @@ impl NavHistory {
         entry
     }
 
-    pub fn push<D: 'static + Send + Any>(
+    pub fn push<D: 'static + Any + Send>(
         &mut self,
         data: Option<D>,
         item: Arc<dyn WeakItemHandle>,
@@ -3937,7 +3940,7 @@ impl NavHistory {
                 }
                 state.backward_stack.push_back(NavigationEntry {
                     item,
-                    data: data.map(|data| Box::new(data) as Box<dyn Any + Send>),
+                    data: data.map(|data| Arc::new(data) as Arc<dyn Any + Send>),
                     timestamp: state.next_timestamp.fetch_add(1, Ordering::SeqCst),
                     is_preview,
                 });
@@ -3949,7 +3952,7 @@ impl NavHistory {
                 }
                 state.forward_stack.push_back(NavigationEntry {
                     item,
-                    data: data.map(|data| Box::new(data) as Box<dyn Any + Send>),
+                    data: data.map(|data| Arc::new(data) as Arc<dyn Any + Send>),
                     timestamp: state.next_timestamp.fetch_add(1, Ordering::SeqCst),
                     is_preview,
                 });
@@ -3960,7 +3963,7 @@ impl NavHistory {
                 }
                 state.backward_stack.push_back(NavigationEntry {
                     item,
-                    data: data.map(|data| Box::new(data) as Box<dyn Any + Send>),
+                    data: data.map(|data| Arc::new(data) as Arc<dyn Any + Send>),
                     timestamp: state.next_timestamp.fetch_add(1, Ordering::SeqCst),
                     is_preview,
                 });
@@ -3971,7 +3974,7 @@ impl NavHistory {
                 }
                 state.closed_stack.push_back(NavigationEntry {
                     item,
-                    data: data.map(|data| Box::new(data) as Box<dyn Any + Send>),
+                    data: data.map(|data| Arc::new(data) as Arc<dyn Any + Send>),
                     timestamp: state.next_timestamp.fetch_add(1, Ordering::SeqCst),
                     is_preview,
                 });

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -254,6 +254,7 @@ impl DeploySearch {
 }
 
 const MAX_NAVIGATION_HISTORY_LEN: usize = 1024;
+const MAX_TAG_STACK_LEN: usize = 32;
 
 pub enum Event {
     AddItem {
@@ -3960,6 +3961,17 @@ impl ItemNavHistory {
         }
     }
 
+    pub fn push_tag<D: 'static + Any + Send>(&mut self, tag: Option<String>, data: Option<D>) {
+        if self
+            .item
+            .upgrade()
+            .is_some_and(|item| item.include_in_nav_history())
+        {
+            self.history
+                .push_tag(tag, data, self.item.clone(), self.is_preview);
+        }
+    }
+
     pub fn pop_backward(&mut self, cx: &mut App) -> Option<NavigationEntry> {
         self.history.pop_backward(cx)
     }
@@ -4062,6 +4074,38 @@ impl NavHistory {
             }
         }
         state.did_update(cx);
+    }
+
+    pub fn push_tag<D: 'static + Any + Send>(
+        &mut self,
+        tag: Option<String>,
+        data: Option<D>,
+        item: Arc<dyn WeakItemHandle>,
+        is_preview: bool,
+    ) {
+        let mut state = self.0.lock();
+        let Some(src) = state.backward_stack.back().cloned() else {
+            return;
+        };
+        let dst = NavigationEntry {
+            item,
+            data: data.map(|item| Arc::new(item) as Arc<dyn Any + Send>),
+            timestamp: src.timestamp,
+            is_preview,
+            is_deleted: false,
+        };
+        state.truncate_tag_stack();
+        if state.tag_stack.len() >= MAX_TAG_STACK_LEN {
+            state.tag_stack.pop_front();
+        }
+        let current = state.current_offset();
+        state.tag_stack.push_back(TagStackEntry {
+            tag,
+            src_entry: src,
+            dst_entry: dst,
+            src_number: Some(current - 1),
+            dst_number: Some(current),
+        });
     }
 
     pub fn remove_item(&mut self, item_id: EntityId) {
@@ -4313,6 +4357,19 @@ impl NavHistoryState {
             }
         }
         (prev, next)
+    }
+    pub fn truncate_tag_stack(&mut self) {
+        loop {
+            let Some(back) = self.tag_stack.back() else {
+                break;
+            };
+            if let Some(dst_number) = back.dst_number
+                && dst_number <= self.current_offset()
+            {
+                break;
+            }
+            self.tag_stack.pop_back();
+        }
     }
 }
 

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -786,6 +786,16 @@ impl Pane {
         &mut self.nav_history
     }
 
+    pub fn fork_nav_history(&self) -> NavHistory {
+        let history = self.nav_history.0.lock().clone();
+        NavHistory(Arc::new(Mutex::new(history)))
+    }
+
+    pub fn set_nav_history(&mut self, history: NavHistory, cx: &Context<Self>) {
+        self.nav_history = history;
+        self.nav_history().0.lock().pane = cx.entity().downgrade();
+    }
+
     pub fn disable_history(&mut self) {
         self.nav_history.disable();
     }

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -200,6 +200,10 @@ actions!(
         GoBack,
         /// Navigates forward in history.
         GoForward,
+        /// Go to the next oldest tag in the tag stack.
+        GoToOlderTag,
+        /// Go to the next newest tag in the tag stack.
+        GoToNewerTag,
         /// Joins this pane into the next pane.
         JoinIntoNext,
         /// Joins all panes into one.
@@ -401,9 +405,22 @@ pub struct NavHistory(Arc<Mutex<NavHistoryState>>);
 #[derive(Clone)]
 struct NavHistoryState {
     mode: NavigationMode,
+    // You can think of every entry in navigation history as being identified by
+    // a history number. Since we only keep the last N navigation entries in
+    // each stack, the oldest element of the backwards stack has history number
+    // `offset`.
+    //
+    // The current pane view does not explicitly live on any of the stacks, but
+    // is implicitly also a member of history. So first all of the backward
+    // stack entries are numbered, then a number is reserved for the current
+    // pane view, then the forward stack's entries. This ensures that history
+    // numbers are a good way to identify history entries even as the user
+    // browses forwards and backwards in history.
+    numbering_offset: usize,
     backward_stack: VecDeque<NavigationEntry>,
     forward_stack: VecDeque<NavigationEntry>,
     closed_stack: VecDeque<NavigationEntry>,
+    tag_stack: VecDeque<TagStackEntry>,
     paths_by_item: HashMap<EntityId, (ProjectPath, Option<PathBuf>)>,
     pane: WeakEntity<Pane>,
     next_timestamp: Arc<AtomicUsize>,
@@ -412,11 +429,20 @@ struct NavHistoryState {
 #[derive(Debug, Copy, Clone)]
 pub enum NavigationMode {
     Normal,
-    GoingBack,
-    GoingForward,
+    GoingBack(usize),
+    GoingForward(usize),
     ClosingItem,
     ReopeningClosedItem,
     Disabled,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum NavigationAction {
+    GoBack,
+    GoForward,
+    GoToOlderTag,
+    GoToNewerTag,
+    ReopenClosedItem,
 }
 
 impl Default for NavigationMode {
@@ -431,6 +457,21 @@ pub struct NavigationEntry {
     pub data: Option<Arc<dyn Any + Send>>,
     pub timestamp: usize,
     pub is_preview: bool,
+    pub is_deleted: bool,
+}
+
+#[derive(Clone)]
+pub struct TagStackEntry {
+    pub tag: Option<String>,
+    // Tag stack entries logically sit between two history entries
+    pub src_entry: NavigationEntry,
+    pub dst_entry: NavigationEntry,
+    // If we've navigated back in history, then explored forward a bit without a
+    // tag stack jump, we could be in a state where we've truncated the forward
+    // navigation history but *not* the forward tag stack. In such a case, one
+    // or both of these offsets may be None.
+    pub src_number: Option<usize>,
+    pub dst_number: Option<usize>,
 }
 
 #[derive(Clone)]
@@ -491,12 +532,14 @@ impl Pane {
             last_focus_handle_by_item: Default::default(),
             nav_history: NavHistory(Arc::new(Mutex::new(NavHistoryState {
                 mode: NavigationMode::Normal,
+                numbering_offset: 0,
                 backward_stack: Default::default(),
                 forward_stack: Default::default(),
                 closed_stack: Default::default(),
                 paths_by_item: Default::default(),
                 pane: handle,
                 next_timestamp,
+                tag_stack: Default::default(),
             }))),
             toolbar: cx.new(|_| Toolbar::new()),
             tab_bar_scroll_handle: ScrollHandle::new(),
@@ -805,11 +848,21 @@ impl Pane {
     }
 
     pub fn can_navigate_backward(&self) -> bool {
-        !self.nav_history.0.lock().backward_stack.is_empty()
+        self.nav_history
+            .0
+            .lock()
+            .backward_stack
+            .iter()
+            .any(|el| !el.is_deleted)
     }
 
     pub fn can_navigate_forward(&self) -> bool {
-        !self.nav_history.0.lock().forward_stack.is_empty()
+        self.nav_history
+            .0
+            .lock()
+            .forward_stack
+            .iter()
+            .any(|el| !el.is_deleted)
     }
 
     pub fn navigate_backward(&mut self, _: &GoBack, window: &mut Window, cx: &mut Context<Self>) {
@@ -830,6 +883,42 @@ impl Pane {
                 workspace.update(cx, |workspace, cx| {
                     workspace
                         .go_forward(pane, window, cx)
+                        .detach_and_log_err(cx)
+                })
+            })
+        }
+    }
+
+    fn navigate_older_tag(
+        &mut self,
+        _: &GoToOlderTag,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(workspace) = self.workspace.upgrade() {
+            let pane = cx.entity().downgrade();
+            window.defer(cx, move |window, cx| {
+                workspace.update(cx, |workspace, cx| {
+                    workspace
+                        .go_to_older_tag(pane, window, cx)
+                        .detach_and_log_err(cx)
+                })
+            })
+        }
+    }
+
+    fn navigate_newer_tag(
+        &mut self,
+        _: &GoToNewerTag,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(workspace) = self.workspace.upgrade() {
+            let pane = cx.entity().downgrade();
+            window.defer(cx, move |window, cx| {
+                workspace.update(cx, |workspace, cx| {
+                    workspace
+                        .go_to_newer_tag(pane, window, cx)
                         .detach_and_log_err(cx)
                 })
             })
@@ -1263,11 +1352,13 @@ impl Pane {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        use NavigationMode::{GoingBack, GoingForward};
         if index < self.items.len() {
             let prev_active_item_ix = mem::replace(&mut self.active_item_index, index);
             if (prev_active_item_ix != self.active_item_index
-                || matches!(self.nav_history.mode(), GoingBack | GoingForward))
+                || matches!(
+                    self.nav_history.mode(),
+                    NavigationMode::GoingBack(_) | NavigationMode::GoingForward(_)
+                ))
                 && let Some(prev_item) = self.items.get(prev_active_item_ix)
             {
                 prev_item.deactivated(window, cx);
@@ -3637,6 +3728,8 @@ impl Render for Pane {
             .on_action(cx.listener(Pane::toggle_zoom))
             .on_action(cx.listener(Self::navigate_backward))
             .on_action(cx.listener(Self::navigate_forward))
+            .on_action(cx.listener(Self::navigate_older_tag))
+            .on_action(cx.listener(Self::navigate_newer_tag))
             .on_action(
                 cx.listener(|pane: &mut Pane, action: &ActivateItem, window, cx| {
                     pane.activate_item(
@@ -3868,11 +3961,7 @@ impl ItemNavHistory {
     }
 
     pub fn pop_backward(&mut self, cx: &mut App) -> Option<NavigationEntry> {
-        self.history.pop(NavigationMode::GoingBack, cx)
-    }
-
-    pub fn pop_forward(&mut self, cx: &mut App) -> Option<NavigationEntry> {
-        self.history.pop(NavigationMode::GoingForward, cx)
+        self.history.pop_backward(cx)
     }
 }
 
@@ -3889,6 +3978,9 @@ impl NavHistory {
             .chain(borrowed_history.backward_stack.iter())
             .chain(borrowed_history.closed_stack.iter())
             .for_each(|entry| {
+                if entry.is_deleted {
+                    return;
+                }
                 if let Some(project_and_abs_path) =
                     borrowed_history.paths_by_item.get(&entry.item.id())
                 {
@@ -3917,21 +4009,36 @@ impl NavHistory {
         self.0.lock().mode = NavigationMode::Normal;
     }
 
-    pub fn pop(&mut self, mode: NavigationMode, cx: &mut App) -> Option<NavigationEntry> {
+    pub fn scry(
+        &mut self,
+        action: NavigationAction,
+        cx: &mut App,
+    ) -> Option<(NavigationEntry, NavigationMode)> {
         let mut state = self.0.lock();
-        let entry = match mode {
-            NavigationMode::Normal | NavigationMode::Disabled | NavigationMode::ClosingItem => {
-                return None;
+        loop {
+            let entry = state.scry(action);
+            if entry.as_ref().map(|e| e.0.is_deleted).unwrap_or(false) {
+                continue;
             }
-            NavigationMode::GoingBack => &mut state.backward_stack,
-            NavigationMode::GoingForward => &mut state.forward_stack,
-            NavigationMode::ReopeningClosedItem => &mut state.closed_stack,
+            if entry.is_some() {
+                state.did_update(cx);
+            }
+            return entry;
         }
-        .pop_back();
-        if entry.is_some() {
-            state.did_update(cx);
+    }
+
+    pub(crate) fn pop_backward(&mut self, cx: &mut App) -> Option<NavigationEntry> {
+        let mut state = self.0.lock();
+        loop {
+            let entry = state.backward_stack.pop_back();
+            if entry.as_ref().map(|e| e.is_deleted).unwrap_or(false) {
+                continue;
+            }
+            if entry.is_some() {
+                state.did_update(cx);
+            }
+            return entry;
         }
-        entry
     }
 
     pub fn push<D: 'static + Any + Send>(
@@ -3941,53 +4048,17 @@ impl NavHistory {
         is_preview: bool,
         cx: &mut App,
     ) {
-        let state = &mut *self.0.lock();
-        match state.mode {
+        let mut state = self.0.lock();
+        let mode = state.mode;
+        match mode {
             NavigationMode::Disabled => {}
-            NavigationMode::Normal | NavigationMode::ReopeningClosedItem => {
-                if state.backward_stack.len() >= MAX_NAVIGATION_HISTORY_LEN {
-                    state.backward_stack.pop_front();
-                }
-                state.backward_stack.push_back(NavigationEntry {
-                    item,
-                    data: data.map(|data| Arc::new(data) as Arc<dyn Any + Send>),
-                    timestamp: state.next_timestamp.fetch_add(1, Ordering::SeqCst),
-                    is_preview,
-                });
-                state.forward_stack.clear();
-            }
-            NavigationMode::GoingBack => {
-                if state.forward_stack.len() >= MAX_NAVIGATION_HISTORY_LEN {
-                    state.forward_stack.pop_front();
-                }
-                state.forward_stack.push_back(NavigationEntry {
-                    item,
-                    data: data.map(|data| Arc::new(data) as Arc<dyn Any + Send>),
-                    timestamp: state.next_timestamp.fetch_add(1, Ordering::SeqCst),
-                    is_preview,
-                });
-            }
-            NavigationMode::GoingForward => {
-                if state.backward_stack.len() >= MAX_NAVIGATION_HISTORY_LEN {
-                    state.backward_stack.pop_front();
-                }
-                state.backward_stack.push_back(NavigationEntry {
-                    item,
-                    data: data.map(|data| Arc::new(data) as Arc<dyn Any + Send>),
-                    timestamp: state.next_timestamp.fetch_add(1, Ordering::SeqCst),
-                    is_preview,
-                });
-            }
-            NavigationMode::ClosingItem => {
-                if state.closed_stack.len() >= MAX_NAVIGATION_HISTORY_LEN {
-                    state.closed_stack.pop_front();
-                }
-                state.closed_stack.push_back(NavigationEntry {
-                    item,
-                    data: data.map(|data| Arc::new(data) as Arc<dyn Any + Send>),
-                    timestamp: state.next_timestamp.fetch_add(1, Ordering::SeqCst),
-                    is_preview,
-                });
+            NavigationMode::Normal
+            | NavigationMode::ReopeningClosedItem
+            | NavigationMode::GoingBack(_)
+            | NavigationMode::GoingForward(_)
+            | NavigationMode::ClosingItem => {
+                let data = data.map(|item| Arc::new(item) as Arc<dyn Any + Send>);
+                state.push(mode, data, item, is_preview);
             }
         }
         state.did_update(cx);
@@ -3996,15 +4067,27 @@ impl NavHistory {
     pub fn remove_item(&mut self, item_id: EntityId) {
         let mut state = self.0.lock();
         state.paths_by_item.remove(&item_id);
-        state
-            .backward_stack
-            .retain(|entry| entry.item.id() != item_id);
-        state
-            .forward_stack
-            .retain(|entry| entry.item.id() != item_id);
+        state.tag_stack.retain(|entry| {
+            entry.src_entry.item.id() != item_id && entry.dst_entry.item.id() != item_id
+        });
         state
             .closed_stack
             .retain(|entry| entry.item.id() != item_id);
+
+        // For the backward and forward stacks, it's a lot less bookkeeping to
+        // mark entries as deleted instead of actually removing them
+        for entry in state.backward_stack.iter_mut() {
+            if entry.item.id() == item_id {
+                entry.is_deleted = true;
+                entry.data = None;
+            }
+        }
+        for entry in state.forward_stack.iter_mut() {
+            if entry.item.id() == item_id {
+                entry.is_deleted = true;
+                entry.data = None;
+            }
+        }
     }
 
     pub fn path_for_item(&self, item_id: EntityId) -> Option<(ProjectPath, Option<PathBuf>)> {
@@ -4013,12 +4096,223 @@ impl NavHistory {
 }
 
 impl NavHistoryState {
+    fn push(
+        &mut self,
+        mode: NavigationMode,
+        data: Option<Arc<dyn Any + Send>>,
+        item: Arc<dyn WeakItemHandle>,
+        is_preview: bool,
+    ) {
+        match mode {
+            NavigationMode::Disabled => {}
+            NavigationMode::Normal | NavigationMode::ReopeningClosedItem => {
+                if self.backward_stack.len() >= MAX_NAVIGATION_HISTORY_LEN {
+                    self.backward_stack.pop_front();
+                    self.numbering_offset += 1;
+                }
+                let offset = self.current_offset();
+                self.backward_stack.push_back(NavigationEntry {
+                    item,
+                    data,
+                    timestamp: self.next_timestamp.fetch_add(1, Ordering::SeqCst),
+                    is_preview,
+                    is_deleted: false,
+                });
+                self.forward_stack.clear();
+                // Clearing the forward stack might cause some tag stack entries
+                // to no longer be members of history
+                for entry in self.tag_stack.iter_mut() {
+                    if let Some(src_number) = entry.src_number
+                        && src_number > offset
+                    {
+                        entry.src_number = None;
+                    }
+                    if let Some(dst_number) = entry.dst_number
+                        && dst_number > offset
+                    {
+                        entry.dst_number = None;
+                    }
+                }
+            }
+            NavigationMode::GoingBack(n) => {
+                let mut item = item;
+                let mut data = data;
+                let mut is_preview = is_preview;
+                for _ in 0..n {
+                    if self.forward_stack.len() >= MAX_NAVIGATION_HISTORY_LEN {
+                        self.forward_stack.pop_front();
+                    }
+                    self.forward_stack.push_back(NavigationEntry {
+                        item,
+                        data,
+                        timestamp: self.next_timestamp.fetch_add(1, Ordering::SeqCst),
+                        is_preview,
+                        is_deleted: false,
+                    });
+                    let Some(entry) = self.backward_stack.pop_back() else {
+                        return;
+                    };
+                    item = entry.item;
+                    data = entry.data;
+                    is_preview = entry.is_preview;
+                }
+            }
+            NavigationMode::GoingForward(n) => {
+                let mut item = item;
+                let mut data = data;
+                let mut is_preview = is_preview;
+                for _ in 0..n {
+                    if self.backward_stack.len() >= MAX_NAVIGATION_HISTORY_LEN {
+                        self.backward_stack.pop_front();
+                    }
+                    self.backward_stack.push_back(NavigationEntry {
+                        item,
+                        data,
+                        timestamp: self.next_timestamp.fetch_add(1, Ordering::SeqCst),
+                        is_preview,
+                        is_deleted: false,
+                    });
+                    let Some(entry) = self.forward_stack.pop_back() else {
+                        return;
+                    };
+                    item = entry.item;
+                    data = entry.data;
+                    is_preview = entry.is_preview;
+                }
+            }
+            NavigationMode::ClosingItem => {
+                if self.closed_stack.len() >= MAX_NAVIGATION_HISTORY_LEN {
+                    self.closed_stack.pop_front();
+                }
+                self.closed_stack.push_back(NavigationEntry {
+                    item,
+                    data,
+                    timestamp: self.next_timestamp.fetch_add(1, Ordering::SeqCst),
+                    is_preview,
+                    is_deleted: false,
+                });
+            }
+        }
+    }
+    // Returns the navigation history entry you would get to if you performed
+    // the given action, plus the navigation mode you need to be in to get to
+    // that point in history.
+    //
+    // This function mostly does *not* mutate history (e.g., such that history
+    // reflects the results of performing the navigation action). That
+    // occurs in `navigate_history` in `workspace.rs` when navigations are
+    // performed with the returned mode.
+    pub fn scry(&mut self, action: NavigationAction) -> Option<(NavigationEntry, NavigationMode)> {
+        match action {
+            NavigationAction::GoBack => self
+                .backward_stack
+                .back()
+                .map(|entry| (entry.clone(), NavigationMode::GoingBack(1))),
+            NavigationAction::GoForward => self
+                .forward_stack
+                .back()
+                .map(|entry| (entry.clone(), NavigationMode::GoingForward(1))),
+            NavigationAction::GoToOlderTag => {
+                let (Some(tag), _) = self.tag_stack_pos() else {
+                    return None;
+                };
+                let entry = tag.src_entry.clone();
+                if let Some(src_number) = tag.src_number
+                    && src_number < self.current_offset()
+                {
+                    Some((
+                        entry,
+                        NavigationMode::GoingBack(self.current_offset() - src_number),
+                    ))
+                } else {
+                    // This case shouldn't happen, but it's easy enough to do
+                    // something sensical if it does
+                    Some((entry, NavigationMode::Normal))
+                }
+            }
+            NavigationAction::GoToNewerTag => {
+                let current_offset = self.current_offset();
+                let (_, Some(tag)) = self.tag_stack_pos() else {
+                    return None;
+                };
+                let entry = tag.dst_entry.clone();
+                match (tag.src_number, tag.dst_number) {
+                    (Some(_), Some(dst_number)) => Some((
+                        entry,
+                        NavigationMode::GoingForward(dst_number - current_offset),
+                    )),
+                    // In the case where one or both of the tag stack jump
+                    // endpoints is not in our forward history (e.g., someone
+                    // has gone back in history and navigated forward on a
+                    // different branch of history), we need to doctor up
+                    // forward history to make the tag stack behave as expected.
+                    //
+                    // Note: this may make the src and dst of a tag stack entry
+                    // be non-adjacent in history, because we don't nuke the
+                    // alternate branch of history prior to doctoring up forward
+                    // history. This is fine.
+                    (Some(src_number), None) => {
+                        let src_entry = tag.src_entry.clone();
+                        if src_number > current_offset {
+                            tag.dst_number = Some(src_number + 1);
+                            while self.forward_stack.len() > src_number - current_offset {
+                                self.forward_stack.pop_front();
+                            }
+                            self.forward_stack.push_front(src_entry);
+                            Some((
+                                entry,
+                                NavigationMode::GoingForward(src_number - current_offset),
+                            ))
+                        } else {
+                            tag.dst_number = Some(current_offset + 1);
+                            self.forward_stack.clear();
+                            self.forward_stack.push_back(src_entry);
+                            Some((entry, NavigationMode::GoingForward(1)))
+                        }
+                    }
+                    (None, _) => {
+                        tag.src_number = Some(current_offset + 1);
+                        tag.dst_number = Some(current_offset + 2);
+                        let src_entry = tag.src_entry.clone();
+                        let dst_entry = tag.src_entry.clone();
+                        self.forward_stack.clear();
+                        self.forward_stack.push_back(dst_entry);
+                        self.forward_stack.push_back(src_entry);
+                        Some((entry, NavigationMode::GoingForward(2)))
+                    }
+                }
+            }
+            NavigationAction::ReopenClosedItem => self
+                .closed_stack
+                .back()
+                .map(|entry| (entry.clone(), NavigationMode::ReopeningClosedItem)),
+        }
+    }
     pub fn did_update(&self, cx: &mut App) {
         if let Some(pane) = self.pane.upgrade() {
             cx.defer(move |cx| {
                 pane.update(cx, |pane, cx| pane.history_updated(cx));
             });
         }
+    }
+    pub fn current_offset(&self) -> usize {
+        self.numbering_offset + self.backward_stack.len()
+    }
+    pub fn tag_stack_pos(&mut self) -> (Option<&mut TagStackEntry>, Option<&mut TagStackEntry>) {
+        let mut prev: Option<&mut TagStackEntry> = None;
+        let mut next: Option<&mut TagStackEntry> = None;
+        let offset = self.current_offset();
+        for entry in self.tag_stack.iter_mut() {
+            if let Some(dst_number) = entry.dst_number
+                && dst_number <= offset
+            {
+                prev = Some(entry);
+            } else {
+                next = Some(entry);
+                break;
+            }
+        }
+        (prev, next)
     }
 }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4085,8 +4085,10 @@ impl Workspace {
         let maybe_pane_handle =
             if let Some(clone) = item.clone_on_split(self.database_id(), window, cx) {
                 let new_pane = self.add_pane(window, cx);
+                let nav_history = pane.read(cx).fork_nav_history();
                 new_pane.update(cx, |pane, cx| {
-                    pane.add_item(clone, true, true, None, window, cx)
+                    pane.set_nav_history(nav_history, cx);
+                    pane.add_item(clone, true, true, None, window, cx);
                 });
                 self.center.split(&pane, &new_pane, direction).unwrap();
                 Some(new_pane)

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1878,7 +1878,7 @@ impl Workspace {
     fn navigate_history(
         &mut self,
         pane: WeakEntity<Pane>,
-        mode: NavigationMode,
+        action: NavigationAction,
         window: &mut Window,
         cx: &mut Context<Workspace>,
     ) -> Task<Result<()>> {
@@ -1887,7 +1887,7 @@ impl Workspace {
                 window.focus(&pane.focus_handle(cx));
                 loop {
                     // Retrieve the weak item handle from the history.
-                    let entry = pane.nav_history_mut().pop(mode, cx)?;
+                    let (entry, mode) = pane.nav_history_mut().scry(action, cx)?;
 
                     // If the item is still present in this pane, then activate it.
                     if let Some(index) = entry
@@ -1914,7 +1914,7 @@ impl Workspace {
                         break pane
                             .nav_history()
                             .path_for_item(entry.item.id())
-                            .map(|(project_path, abs_path)| (project_path, abs_path, entry));
+                            .map(|(project_path, abs_path)| (project_path, abs_path, entry, mode));
                     }
                 }
             })
@@ -1922,7 +1922,7 @@ impl Workspace {
             None
         };
 
-        if let Some((project_path, abs_path, entry)) = to_load {
+        if let Some((project_path, abs_path, entry, mode)) = to_load {
             // If the item was no longer present, then load it again from its previous path, first try the local path
             let open_by_project_path = self.load_path(project_path.clone(), window, cx);
 
@@ -1991,7 +1991,7 @@ impl Workspace {
                 if !navigated {
                     workspace
                         .update_in(cx, |workspace, window, cx| {
-                            Self::navigate_history(workspace, pane, mode, window, cx)
+                            Self::navigate_history(workspace, pane, action, window, cx)
                         })?
                         .await?;
                 }
@@ -2009,7 +2009,7 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Workspace>,
     ) -> Task<Result<()>> {
-        self.navigate_history(pane, NavigationMode::GoingBack, window, cx)
+        self.navigate_history(pane, NavigationAction::GoBack, window, cx)
     }
 
     pub fn go_forward(
@@ -2018,7 +2018,25 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Workspace>,
     ) -> Task<Result<()>> {
-        self.navigate_history(pane, NavigationMode::GoingForward, window, cx)
+        self.navigate_history(pane, NavigationAction::GoForward, window, cx)
+    }
+
+    pub fn go_to_older_tag(
+        &mut self,
+        pane: WeakEntity<Pane>,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) -> Task<Result<()>> {
+        self.navigate_history(pane, NavigationAction::GoToOlderTag, window, cx)
+    }
+
+    pub fn go_to_newer_tag(
+        &mut self,
+        pane: WeakEntity<Pane>,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) -> Task<Result<()>> {
+        self.navigate_history(pane, NavigationAction::GoToNewerTag, window, cx)
     }
 
     pub fn reopen_closed_item(
@@ -2028,7 +2046,7 @@ impl Workspace {
     ) -> Task<Result<()>> {
         self.navigate_history(
             self.active_pane().downgrade(),
-            NavigationMode::ReopeningClosedItem,
+            NavigationAction::ReopenClosedItem,
             window,
             cx,
         )


### PR DESCRIPTION
Fix bug where navigating to an unopened file does not add an entry to the tag stack.

Use target location for inlay hint origin. 
My understanding is that origin is only used for the text of the tag. So, for inlay hints, the target is a valid "origin". 
